### PR TITLE
Add date arithmetic and highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A tiny Electron calculator that evaluates each line as you type. Expressions are
 - Line-by-line calculations with syntax highlighting
 - Currency, percent, and `$name =` variable support
 - Unit-aware calculations and conversions
+- Date-aware calculations with ISO dates and the `today` keyword
 - Copyable results and persistent tabs/settings across sessions
 - Configurable gradients, themes, window size, and font size
 
@@ -19,6 +20,7 @@ Detailed documentation for Equals lives in the [docs](docs) directory:
 - [Unit tokens](docs/units.md) – compact measurements and conversions such as `5cm` or `32F to C`.
 - [Variables and references](docs/variables.md) – reuse values with `$name` and `""`.
 - [Time expressions](docs/time.md) – mix `12:30pm`, `2h`, `45m`, and more.
+- [Date expressions](docs/dates.md) – ISO dates and the `today` keyword.
 - [Currency, percent, and number formatting](docs/formatting.md) – locale-aware output.
 - [Tabs and settings](docs/interface.md) – managing tabs, themes, and window options.
 

--- a/docs/dates.md
+++ b/docs/dates.md
@@ -1,0 +1,13 @@
+# Date Expressions
+
+Equals can parse ISO-style dates like `2024-05-15` and the keyword `today`.
+These tokens are converted to day counts so you can add or subtract days or
+measure the difference between two dates.
+
+Results are shown as dates when any date token is involved. When only day counts
+are present, the result is formatted as a duration in days.
+
+## Examples
+- `today + 3 days` → `2024-05-18` (if today is `2024-05-15`)
+- `2024-06-01 - 2024-05-15` → `17 days`
+- `2024-06-01 + 2d` → `2024-06-03`

--- a/style.css
+++ b/style.css
@@ -27,6 +27,7 @@ body {
   --time-color: #e06c75;
   --trig-color: #ff6bcb;
   --unit-color: #9ece6a;
+  --date-color: #e0c074;
   --settings-bg: rgba(16,16,16,0.9);
   --settings-border: rgba(255,255,255,0.1);
   --divider-color: rgba(255,255,255,0.05);
@@ -47,6 +48,7 @@ body.light {
   --time-color: #d32f2f;
   --trig-color: #d23669;
   --unit-color: #6e9e00;
+  --date-color: #b58400;
   --settings-bg: rgba(255,255,255,0.8);
   --settings-border: rgba(0,0,0,0.1);
   --divider-color: rgba(0,0,0,0.15);
@@ -135,7 +137,8 @@ body.light {
 .variable,
 .time,
 .last,
-.unit {
+.unit,
+.date {
   background-clip: text;
   -webkit-background-clip: text;
   color: transparent;
@@ -196,6 +199,14 @@ body.light {
     135deg,
     color-mix(in srgb, var(--time-color) 70%, white),
     var(--time-color)
+  );
+}
+
+.date {
+  background-image: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--date-color) 70%, white),
+    var(--date-color)
   );
 }
 


### PR DESCRIPTION
## Summary
- parse ISO-style dates and the `today` keyword into day counts
- evaluate date expressions and format results as dates or day differences
- style and highlight date tokens in the UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52fcebe54832f98a9f49730a5463b