### PR TITLE
Enable range expressions and aggregate helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Detailed documentation for Equals lives in the [docs](docs) directory:
 
 - [Unit tokens](docs/units.md) – compact measurements and conversions such as `5cm` or `32F to C`.
 - [Variables and references](docs/variables.md) – reuse values with `$name` and `""`.
+- [Range expressions](docs/ranges.md) – aggregate lines or variables with `1..5` and `$a:$d`.
 - [Time expressions](docs/time.md) – mix `12:30pm`, `2h`, `45m`, and more.
 - [Date expressions](docs/dates.md) – ISO dates and the `today` keyword.
 - [Currency, percent, and number formatting](docs/formatting.md) – locale-aware output.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Detailed documentation for Equals lives in the [docs](docs) directory:
 
 - [Unit tokens](docs/units.md) – compact measurements and conversions such as `5cm` or `32F to C`.
 - [Variables and references](docs/variables.md) – reuse values with `$name` and `""`.
-- [Range expressions](docs/ranges.md) – aggregate lines or variables with `1..5` and `$a:$d`.
+- [Range expressions](docs/ranges.md) – aggregate numbers or variables with `1..5` and `$a:$d`.
 - [Time expressions](docs/time.md) – mix `12:30pm`, `2h`, `45m`, and more.
 - [Date expressions](docs/dates.md) – ISO dates and the `today` keyword.
 - [Currency, percent, and number formatting](docs/formatting.md) – locale-aware output.

--- a/__tests__/renderer.test.js
+++ b/__tests__/renderer.test.js
@@ -9,6 +9,7 @@ jest.mock('electron', () => ({
 
 let renderer;
 let ipcRenderer;
+const math = require('mathjs');
 
 function setupDOM() {
   document.body.innerHTML = `
@@ -135,6 +136,24 @@ test('compute evaluates complex arithmetic expressions', () => {
   const trig = renderer.compute('sin(90)+cos(0)', [], []);
   expect(complex.value).toBeCloseTo(11.5);
   expect(trig.value).toBeCloseTo(2);
+});
+
+test('compute handles line and variable ranges with aggregate helpers', () => {
+  const lineResults = [1, 2, 3, 4, 5];
+  const avg = renderer.compute('avg(1..5)', lineResults, []);
+  expect(avg.value).toBe(3);
+  const mean = renderer.compute('mean(1..5)', lineResults, []);
+  expect(mean.value).toBe(3);
+  renderer.vars.a = { value: 1 };
+  renderer.vars.b = { value: 2 };
+  renderer.vars.c = { value: 3 };
+  renderer.vars.d = { value: 4 };
+  const sum = renderer.compute('sum($a:$d)', [], []);
+  expect(sum.value).toBe(10);
+  const median = renderer.compute('median(1..5)', lineResults, []);
+  expect(median.value).toBe(3);
+  const std = renderer.compute('std(1..5)', lineResults, []);
+  expect(std.value).toBeCloseTo(math.std(lineResults));
 });
 
 test('enter on empty line inserts a new line below', () => {

--- a/__tests__/renderer.test.js
+++ b/__tests__/renderer.test.js
@@ -156,6 +156,25 @@ test('compute handles line and variable ranges with aggregate helpers', () => {
   expect(std.value).toBeCloseTo(math.std(lineResults));
 });
 
+test('variable assignments persist across computations', () => {
+  const assign = renderer.compute('$a = 1', [], []);
+  expect(assign.value).toBe(1);
+  renderer.vars[assign.assign] = { value: assign.value };
+  const res = renderer.compute('$a + 2', [], []);
+  expect(res.value).toBe(3);
+});
+
+test('pasting multiple lines splits into separate lines', () => {
+  const container = document.getElementById('container');
+  const expr = container.querySelector('.expr[data-index="0"]');
+  expr.textContent = '$a = 1\n$a + 2';
+  expr.dispatchEvent(new Event('input', { bubbles: true }));
+  const lines = container.querySelectorAll('.line');
+  expect(lines.length).toBe(2);
+  const second = container.querySelector('.res[data-index="1"]');
+  expect(second.textContent).toBe('3');
+});
+
 test('enter on empty line inserts a new line below', () => {
   const container = document.getElementById('container');
   const expr = container.querySelector('.expr[data-index="0"]');

--- a/__tests__/renderer.test.js
+++ b/__tests__/renderer.test.js
@@ -186,3 +186,12 @@ test('enter on empty line inserts a new line below', () => {
   );
   expect(document.activeElement.dataset.index).toBe('2');
 });
+
+test('line deletion does not create an extra blank line', () => {
+  const container = document.getElementById('container');
+  const expr = container.querySelector('.expr[data-index="0"]');
+  expr.textContent = '\n';
+  expr.dispatchEvent(new Event('input', { bubbles: true }));
+  const lines = container.querySelectorAll('.line');
+  expect(lines.length).toBe(1);
+});

--- a/docs/ranges.md
+++ b/docs/ranges.md
@@ -1,0 +1,21 @@
+# Range expressions
+
+Equals supports range syntax for aggregating multiple results.
+
+- `1..5` expands to the values from lines 1 through 5.
+- `$a:$d` expands to the values of variables `$a` through `$d`.
+
+These ranges can be passed to helper functions such as `sum`, `avg`, `mean`, `median`, and `std`.
+
+Examples:
+
+```
+$a = 1
+$b = 2
+$c = 3
+$d = 4
+sum($a:$d)   # 10
+avg(1..4)    # 2.5
+median(1..5) # 3
+std(1..5)    # 1.4142
+```

--- a/docs/ranges.md
+++ b/docs/ranges.md
@@ -2,7 +2,7 @@
 
 Equals supports range syntax for aggregating multiple results.
 
-- `1..5` expands to the values from lines 1 through 5.
+- `1..5` expands to the numbers 1 through 5.
 - `$a:$d` expands to the values of variables `$a` through `$d`.
 
 These ranges can be passed to helper functions such as `sum`, `avg`, `mean`, `median`, and `std`.
@@ -17,5 +17,5 @@ $d = 4
 sum($a:$d)   # 10
 avg(1..4)    # 2.5
 median(1..5) # 3
-std(1..5)    # 1.4142
+std(1..5)    # 1.5811
 ```

--- a/renderer.js
+++ b/renderer.js
@@ -266,8 +266,7 @@ function expandRanges(expr, results, vars) {
       const step = start <= end ? 1 : -1;
       const arr = [];
       for (let i = start; step > 0 ? i <= end : i >= end; i += step) {
-        const v = results[i - 1];
-        arr.push(typeof v === 'number' ? v : 0);
+        arr.push(i);
       }
       return `[${arr.join(',')}]`;
     })
@@ -581,6 +580,8 @@ function onInput(e) {
   raw = raw.replace(/([$€£])(\d+)(\.?)(\d*)/g, (_, sym, intp, dot, dec) => {
     return sym + intp + (dot ? '.' + dec.slice(0, 2) : '');
   });
+  // strip a trailing newline inserted by contentEditable
+  raw = raw.replace(/\r?\n$/, '');
   const parts = raw.split(/\n/);
   if (parts.length > 1) {
     tabs[currentTab].lines.splice(index, 1, ...parts);

--- a/style.css
+++ b/style.css
@@ -23,6 +23,7 @@ body {
   --percent-color: #56b6c2;
   --currency-color: #bb87f8;
   --var-color: #c678dd;
+  --range-color: #00b0ff;
   --comment-color: #6a9955;
   --time-color: #e06c75;
   --trig-color: #ff6bcb;
@@ -44,6 +45,7 @@ body.light {
   --percent-color: #006b75;
   --currency-color: #6a1b9a;
   --var-color: #8e44ad;
+  --range-color: #005d8f;
   --comment-color: #008000;
   --time-color: #d32f2f;
   --trig-color: #d23669;
@@ -138,6 +140,7 @@ body.light {
 .time,
 .last,
 .unit,
+.range,
 .date {
   background-clip: text;
   -webkit-background-clip: text;
@@ -183,6 +186,14 @@ body.light {
     135deg,
     color-mix(in srgb, var(--var-color) 70%, white),
     var(--var-color)
+  );
+}
+
+.range {
+  background-image: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--range-color) 70%, white),
+    var(--range-color)
   );
 }
 


### PR DESCRIPTION
## Summary
- Parse numeric and variable ranges like `1..5` and `$a:$d`
- Expose aggregate helpers `avg`, `mean`, `median`, `std`
- Highlight range tokens with dedicated styling and document usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b541f47424832f9d7f573eb499bb39