### PR TITLE
Add keyboard shortcuts for tabs and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A tiny Electron calculator that evaluates each line as you type. Expressions are
 - Date-aware calculations with ISO dates and the `today` keyword
 - Copyable results and persistent tabs/settings across sessions
 - Configurable gradients, themes, window size, and font size
+- Keyboard shortcuts for tab management and settings (`Ctrl+T` new tab, `Ctrl+Tab` cycle tabs, `Ctrl+,` open settings)
 
 ## Wiki
 Detailed documentation for Equals lives in the [docs](docs) directory:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A tiny Electron calculator that evaluates each line as you type. Expressions are
 - Date-aware calculations with ISO dates and the `today` keyword
 - Copyable results and persistent tabs/settings across sessions
 - Configurable gradients, themes, window size, and font size
-- Keyboard shortcuts for tab management and settings (`Ctrl+T` new tab, `Ctrl+Tab` cycle tabs, `Ctrl+,` open settings)
+- Keyboard shortcuts for tab management and settings (`Ctrl+T` new tab, `Ctrl+Tab` cycle tabs, `Ctrl+=` open settings)
 
 ## Wiki
 Detailed documentation for Equals lives in the [docs](docs) directory:

--- a/renderer.js
+++ b/renderer.js
@@ -699,6 +699,7 @@ function renderTabMenu() {
       tabMenu.classList.add('hidden');
       renderTab();
       saveState();
+      showToast(`Switched to ${tabs[currentTab].name}`);
     });
       const edit = document.createElement('span');
       edit.className = 'tab-edit';
@@ -748,6 +749,7 @@ function renderTabMenu() {
     tabMenu.classList.add('hidden');
     renderTab();
     saveState();
+    showToast(`Created ${tabs[currentTab].name}`);
   });
   tabMenu.appendChild(newItem);
 }
@@ -778,6 +780,7 @@ document.addEventListener('keydown', (e) => {
     tabMenu.classList.add('hidden');
     renderTab();
     saveState();
+    showToast(`Switched to ${tabs[currentTab].name}`);
   } else if (e.key.toLowerCase() === 't') {
     e.preventDefault();
     tabs.push({ name: `Tab ${tabs.length + 1}`, lines: [''] });
@@ -785,7 +788,8 @@ document.addEventListener('keydown', (e) => {
     tabMenu.classList.add('hidden');
     renderTab();
     saveState();
-  } else if (e.key === ',') {
+    showToast(`Created ${tabs[currentTab].name}`);
+  } else if (e.key === '=') {
     e.preventDefault();
     settingsBtn.click();
   }

--- a/renderer.js
+++ b/renderer.js
@@ -769,6 +769,28 @@ document.addEventListener('click', (e) => {
   }
 });
 
+document.addEventListener('keydown', (e) => {
+  if (!(e.ctrlKey || e.metaKey)) return;
+
+  if (e.key === 'Tab') {
+    e.preventDefault();
+    currentTab = (currentTab + 1) % tabs.length;
+    tabMenu.classList.add('hidden');
+    renderTab();
+    saveState();
+  } else if (e.key.toLowerCase() === 't') {
+    e.preventDefault();
+    tabs.push({ name: `Tab ${tabs.length + 1}`, lines: [''] });
+    currentTab = tabs.length - 1;
+    tabMenu.classList.add('hidden');
+    renderTab();
+    saveState();
+  } else if (e.key === ',') {
+    e.preventDefault();
+    settingsBtn.click();
+  }
+});
+
 settingsBtn.addEventListener('click', () => {
   const showing = !settingsView.classList.toggle('hidden');
   container.classList.toggle('hidden', showing);


### PR DESCRIPTION
## Summary
- Add global keydown listener to manage tabs and open settings via shortcuts
- Document keyboard shortcuts in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b56184329c832f8b6ae7d8da0fe470