### PR TITLE
feat: allow manual window resizing

### DIFF
--- a/__tests__/renderer.test.js
+++ b/__tests__/renderer.test.js
@@ -29,9 +29,12 @@ function setupDOM() {
       <option value="#a,#b"></option>
       <option value="#000000,#ffffff"></option>
     </select>
-    <select id="size-select">
-      <option value="300,300"></option>
-    </select>
+      <select id="size-select">
+        <option value="250,250"></option>
+        <option value="300,300"></option>
+        <option value="400,400"></option>
+        <option value="custom"></option>
+      </select>
     <input id="font-size" />
     <select id="angle-mode">
       <option value="deg"></option>

--- a/index.html
+++ b/index.html
@@ -53,13 +53,14 @@
       </div>
       </div>
     <div class="setting">
-      <label for="size-select">Window Size:</label>
-      <select id="size-select">
-        <option value="250,250" selected>Small</option>
-        <option value="300,300">Medium</option>
-        <option value="400,400">Large</option>
-      </select>
-    </div>
+        <label for="size-select">Window Size:</label>
+        <select id="size-select">
+          <option value="250,250" selected>Small (250×250)</option>
+          <option value="300,300">Medium (300×300)</option>
+          <option value="400,400">Large (400×400)</option>
+          <option value="custom">Custom</option>
+        </select>
+      </div>
     <div class="setting">
       <label for="font-size">Font Size:</label>
       <input id="font-size" type="number" min="12" max="24" value="16" />

--- a/main.js
+++ b/main.js
@@ -7,7 +7,7 @@ function createWindow() {
     height: 250,
     minWidth: 250,
     minHeight: 250,
-    resizable: false,
+    resizable: true,
     frame: false,
     transparent: true,
     titleBarStyle: 'hidden',
@@ -92,9 +92,7 @@ ipcMain.on('window:resize', (e, size) => {
   const h = Number(size?.height);
   if (Number.isFinite(w) && Number.isFinite(h)) {
     win.setResizable(true);
-    win.setMinimumSize(w, h);
     win.setSize(w, h);
-    setTimeout(() => win.setResizable(false), 0);
   }
 });
 

--- a/renderer.js
+++ b/renderer.js
@@ -98,7 +98,13 @@ function loadState() {
     if (saved.settings) {
       themeSelect.value = saved.settings.theme || 'dark';
       gradientSelect.value = saved.settings.gradient || '#bb87f8,#7aa2f7';
-      sizeSelect.value = (saved.settings.size && saved.settings.size.includes(',')) ? saved.settings.size : '250,250';
+      if (saved.settings.size && saved.settings.size.includes(',')) {
+        sizeSelect.value = saved.settings.size;
+      } else if (saved.settings.size === 'custom') {
+        sizeSelect.value = 'custom';
+      } else {
+        sizeSelect.value = '250,250';
+      }
       fontSizeInput.value = saved.settings.fontSize || 16;
       angleModeSelect.value = saved.settings.angleMode || 'deg';
     }
@@ -851,7 +857,21 @@ angleModeSelect.addEventListener('change', () => {
 });
 
 renderTab();
-window.addEventListener('resize', updateDivider);
+
+function handleWindowResize() {
+  const sizeValue = `${window.innerWidth},${window.innerHeight}`;
+  const values = Array.from(sizeSelect.options)
+    .map(o => o.value)
+    .filter(v => v.includes(','));
+  if (values.includes(sizeValue)) {
+    sizeSelect.value = sizeValue;
+  } else {
+    sizeSelect.value = 'custom';
+  }
+  updateDivider();
+}
+
+window.addEventListener('resize', handleWindowResize);
 
 module.exports = {
   deg2rad,


### PR DESCRIPTION
## Summary
- make main window resizable and keep it resizable after scripted size changes
- expand window size options with preset dimensions and a custom mode
- track manual window size changes to update the size selector

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5f465b694832f9e7746b58d396dfa