### PR TITLE
feat: show banner on finish page

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "nsis": {
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
-      "runAfterFinish": true
+      "runAfterFinish": true,
+      "installerSidebar": "app/icons/equals_banner.png"
     }
   }
 }


### PR DESCRIPTION
## Summary
- show Equals banner on installer finish screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b604d96b64832fa693ad89ac036b80