### PR TITLE
Fix help wiki rendering

### DIFF
--- a/app/help.js
+++ b/app/help.js
@@ -1,7 +1,7 @@
 const { ipcRenderer } = require('electron');
 const fs = require('fs');
 const path = require('path');
-const { marked } = require('marked');
+const marked = require('marked');
 
 const container = document.getElementById('container');
 const minBtn = document.getElementById('min-btn');

--- a/app/help.js
+++ b/app/help.js
@@ -3,6 +3,10 @@ const fs = require('fs');
 const path = require('path');
 const marked = require('marked');
 
+const docsDir = fs.existsSync(path.join(__dirname, 'docs'))
+  ? path.join(__dirname, 'docs')
+  : path.join(__dirname, '..', 'docs');
+
 const container = document.getElementById('container');
 const minBtn = document.getElementById('min-btn');
 const maxBtn = document.getElementById('max-btn');
@@ -26,7 +30,6 @@ function mdToHtml(md) {
 }
 
 function showIndex() {
-  const docsDir = path.join(__dirname, '..', 'docs');
   const files = fs.readdirSync(docsDir).filter(f => f.endsWith('.md')).sort();
   const list = files.map(f => `<li><a href="#" data-file="${f}">${f.replace('.md','')}</a></li>`).join('');
   container.innerHTML = `<nav id="toc"><h2>Help Topics</h2><ul class="toc-list">${list}</ul></nav>`;
@@ -40,7 +43,7 @@ function showIndex() {
 }
 
 function showDoc(file) {
-  const filePath = path.join(__dirname, '..', 'docs', file);
+  const filePath = path.join(docsDir, file);
   const text = fs.readFileSync(filePath, 'utf8');
   container.innerHTML = `<button id="back-btn">Back</button><div id="help-content">${mdToHtml(text)}</div>`;
   document.getElementById('back-btn').addEventListener('click', showIndex);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "equals",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "equals",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "electron-updater": "^6.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "equals",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A minimalist's calculator. just type rows, have tabs, etc",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Use default marked import in help window to ensure wiki markdown renders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b60f6059d0832fa73645758dc1a208