### PR TITLE
Log auto-update errors

### DIFF
--- a/__tests__/updater.test.js
+++ b/__tests__/updater.test.js
@@ -23,9 +23,18 @@ test('initAutoUpdate checks for updates and prompts to install', async () => {
   });
   expect(updater.checkForUpdatesAndNotify).toHaveBeenCalled();
 
-  const handler = updater.on.mock.calls.find(([e]) => e === 'update-downloaded')[1];
-  await handler();
+  const calls = updater.on.mock.calls;
+
+  const downloadHandler = calls.find(([e]) => e === 'update-downloaded')[1];
+  await downloadHandler();
   expect(mockShowMessageBox).toHaveBeenCalled();
   expect(updater.quitAndInstall).toHaveBeenCalled();
+
+  const errorHandler = calls.find(([e]) => e === 'error')[1];
+  const mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const err = new Error('boom');
+  errorHandler(err);
+  expect(mockConsoleError).toHaveBeenCalledWith('Auto update error:', err);
+  mockConsoleError.mockRestore();
 });
 

--- a/app/auto-updater.js
+++ b/app/auto-updater.js
@@ -1,6 +1,15 @@
 const { autoUpdater } = require('electron-updater');
 const { dialog } = require('electron');
 
+let log;
+try {
+  // Use electron-log when available to surface errors in packaged builds
+  log = require('electron-log');
+} catch (err) {
+  // Fallback to console.error in development or when electron-log isn't installed
+  log = console;
+}
+
 function initAutoUpdate() {
   autoUpdater.forceDevUpdateConfig = true;
   autoUpdater.setFeedURL({
@@ -22,6 +31,11 @@ function initAutoUpdate() {
           autoUpdater.quitAndInstall();
         }
       });
+  });
+
+  // surface errors so they are visible in builds
+  autoUpdater.on('error', (error) => {
+    log.error('Auto update error:', error);
   });
 
   // check GitHub for updates and download the latest installer


### PR DESCRIPTION
## Summary
- log auto updater errors via electron-log with console fallback
- add tests to ensure errors are surfaced

## Testing
- `npm test -- -w 1`


------
https://chatgpt.com/codex/tasks/task_e_68b62c0b1798832fbe22aadd0c035dd6