### PR TITLE
fix: remove dev update config

### DIFF
--- a/__tests__/updater.test.js
+++ b/__tests__/updater.test.js
@@ -15,7 +15,7 @@ test('initAutoUpdate checks for updates and prompts to install', async () => {
   const updater = mockUpdateAvailable();
   await initAutoUpdate();
 
-  expect(updater.forceDevUpdateConfig).toBe(true);
+  expect(updater.forceDevUpdateConfig).toBeUndefined();
   expect(updater.setFeedURL).toHaveBeenCalledWith({
     provider: 'github',
     owner: 'darkharasho',

--- a/app/auto-updater.js
+++ b/app/auto-updater.js
@@ -2,7 +2,6 @@ const { autoUpdater } = require('electron-updater');
 const { dialog } = require('electron');
 
 function initAutoUpdate() {
-  autoUpdater.forceDevUpdateConfig = true;
   autoUpdater.setFeedURL({
     provider: 'github',
     owner: 'darkharasho',


### PR DESCRIPTION
## Summary
- remove `forceDevUpdateConfig` so packaged builds use production update settings
- update updater test to reflect production config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b67ca74028832fa999994d41f34e33