### PR TITLE
Remove standalone build

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Detailed documentation for Equals lives in the [docs](docs) directory:
 ## Building
 1. Run `npm install`
 2. Create an installer with `npm run build`
-   - Also produces a standalone portable `.zip` alongside the setup executable in `dist`
    - The installer lets you choose the install location, optionally launches the app when finished, and includes an uninstaller
    - Any running instance of the app is closed and previous `dist` output is removed before building to prevent file-in-use errors
    - When publishing, upload the generated `latest.yml` and installers to a GitHub release so the auto-updater can detect new versions

--- a/app/scripts/build-installer.js
+++ b/app/scripts/build-installer.js
@@ -1,7 +1,6 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const AdmZip = require('adm-zip');
 
 const pkg = require('../../package.json');
 const version = pkg.version.replace(/\./g, '_');
@@ -14,18 +13,6 @@ function run(cmd, opts = {}) {
 // clean dist
 fs.rmSync(distDir, { recursive: true, force: true });
 fs.mkdirSync(distDir);
-
-// build portable using electron-packager
-run(`npx electron-packager . Equals --platform=win32 --arch=x64 --icon=app/icons/equals.png --out=dist --overwrite`);
-
-// zip portable folder
-const portableDir = path.join(distDir, 'Equals-win32-x64');
-if (fs.existsSync(portableDir)) {
-  const zip = new AdmZip();
-  zip.addLocalFolder(portableDir);
-  zip.writeZip(path.join(distDir, `Equals-${version}-standalone.zip`));
-}
-
 // build installer
 run('npx electron-builder --win', {
   env: { ...process.env, CSC_IDENTITY_AUTO_DISCOVERY: 'false' }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "mathjs": "^14.6.0"
       },
       "devDependencies": {
-        "adm-zip": "^0.5.16",
         "electron": "^37.4.0",
         "electron-builder": "^26.0.12",
         "electron-packager": "^17.1.2",
@@ -2569,16 +2568,6 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0"
-      }
     },
     "node_modules/agent-base": {
       "version": "7.1.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "mathjs": "^14.6.0"
   },
   "devDependencies": {
-    "adm-zip": "^0.5.16",
     "electron": "^37.4.0",
     "electron-builder": "^26.0.12",
     "electron-packager": "^17.1.2",


### PR DESCRIPTION
## Summary
- stop build-installer from creating a standalone zip and only produce the installer
- drop adm-zip from dev dependencies and update docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b67e694744832fa66b8a4678f10605