### PR TITLE
Auto version Windows installer via artifactName

### DIFF
--- a/app/scripts/build-installer.js
+++ b/app/scripts/build-installer.js
@@ -2,8 +2,6 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const pkg = require('../../package.json');
-const version = pkg.version.replace(/\./g, '_');
 const distDir = path.join(__dirname, '..', '..', 'dist');
 
 function run(cmd, opts = {}) {
@@ -17,9 +15,3 @@ fs.mkdirSync(distDir);
 run('npx electron-builder --win', {
   env: { ...process.env, CSC_IDENTITY_AUTO_DISCOVERY: 'false' }
 });
-
-// rename installer
-const installer = path.join(distDir, 'Equals Setup.exe');
-if (fs.existsSync(installer)) {
-  fs.renameSync(installer, path.join(distDir, `Equals-${version}-setup.exe`));
-}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "build": {
     "appId": "com.equals.app",
     "productName": "Equals",
+    "artifactName": "Equals-${version}-setup.${ext}",
     "directories": {
       "output": "dist"
     },


### PR DESCRIPTION
## Summary
- configure electron-builder to output versioned installers via `artifactName`
- drop manual renaming step in installer build script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b686f64434832fa70d96650e9d9309