### PR TITLE
Replace update dialog with toast prompt

### DIFF
--- a/__tests__/renderer.test.js
+++ b/__tests__/renderer.test.js
@@ -3,7 +3,8 @@
 jest.mock('electron', () => ({
   ipcRenderer: {
     send: jest.fn(),
-    invoke: jest.fn().mockResolvedValue('1.0.0')
+    invoke: jest.fn().mockResolvedValue('1.0.0'),
+    on: jest.fn()
   }
 }));
 

--- a/app/auto-updater.js
+++ b/app/auto-updater.js
@@ -1,5 +1,5 @@
 const { autoUpdater } = require('electron-updater');
-const { dialog } = require('electron');
+const { BrowserWindow, ipcMain } = require('electron');
 
 function initAutoUpdate() {
   autoUpdater.setFeedURL({
@@ -7,20 +7,16 @@ function initAutoUpdate() {
     owner: 'darkharasho',
     repo: 'Equals'
   });
-  // show a prompt once the update has been downloaded
+  // notify renderer to show a toast once the update has been downloaded
   autoUpdater.on('update-downloaded', () => {
-    dialog
-      .showMessageBox({
-        type: 'info',
-        title: 'Update Ready',
-        message: 'A new version has been downloaded. Install now?',
-        buttons: ['Install', 'Later']
-      })
-      .then((result) => {
-        if (result.response === 0) {
-          autoUpdater.quitAndInstall();
-        }
-      });
+    BrowserWindow.getAllWindows().forEach(win => {
+      win.webContents.send('update-downloaded');
+    });
+  });
+
+  // listen for confirmation from the renderer to install the update
+  ipcMain.on('update:install', () => {
+    autoUpdater.quitAndInstall();
   });
 
   // check GitHub for updates and download the latest installer

--- a/renderer.js
+++ b/renderer.js
@@ -222,6 +222,12 @@ ipcRenderer.invoke('app:version').then(v => {
   if (versionEl) versionEl.textContent = 'v' + v;
 });
 
+ipcRenderer.on('update-downloaded', () => {
+  showConfirmToast('A new version has been downloaded. Install now?', () => {
+    ipcRenderer.send('update:install');
+  }, 'Install');
+});
+
 minBtn.addEventListener('click', () => ipcRenderer.send('window:minimize'));
 maxBtn.addEventListener('click', () => ipcRenderer.send('window:maximize'));
 closeBtn.addEventListener('click', () => ipcRenderer.send('window:close'));
@@ -612,9 +618,9 @@ function showToast(msg) {
   setTimeout(() => toast.classList.remove('show'), 1000);
 }
 
-function showConfirmToast(msg, onConfirm) {
+function showConfirmToast(msg, onConfirm, confirmText = 'Close') {
   toast.innerHTML =
-    `<span class="toast-msg">${msg}</span><button class="toast-confirm">Close</button><button class="toast-close">×</button>`;
+    `<span class="toast-msg">${msg}</span><button class="toast-confirm">${confirmText}</button><button class="toast-close">×</button>`;
   toast.classList.add('show', 'confirm');
   const hide = () => {
     toast.classList.remove('show', 'confirm');


### PR DESCRIPTION
## Summary
- replace native update dialog with in-app toast
- allow confirm toast to customize button text
- show toast when an update is ready and trigger install on confirmation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b691cdc190832fb301ca66b7ae0747