### PR TITLE
Ensure light theme uses black accents

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -129,7 +129,7 @@ function updateGradient(value) {
   const grad = `linear-gradient(to right, ${c1}, ${c2})`;
   gradientSelect.style.backgroundImage = '';
   gradientSelect.style.backgroundColor = 'var(--settings-bg)';
-  gradientSelect.style.color = '#fff';
+  gradientSelect.style.color = document.body.classList.contains('light') ? '#000' : '#fff';
   if (gradientPreview) gradientPreview.style.background = grad;
 }
 
@@ -171,7 +171,7 @@ function updateSyntaxGradient(value) {
     }
     syntaxSelect.style.backgroundImage = '';
     syntaxSelect.style.backgroundColor = 'var(--settings-bg)';
-    syntaxSelect.style.color = '#fff';
+    syntaxSelect.style.color = document.body.classList.contains('light') ? '#000' : '#fff';
     if (syntaxPreview)
       syntaxPreview.style.background = 'linear-gradient(to right, #7aa2f7, #ffb454, #6a9955, #ff6bcb)';
     return;
@@ -199,7 +199,7 @@ function updateSyntaxGradient(value) {
   const grad = `linear-gradient(to right, ${c1}, ${c2})`;
   syntaxSelect.style.backgroundImage = '';
   syntaxSelect.style.backgroundColor = 'var(--settings-bg)';
-  syntaxSelect.style.color = '#fff';
+  syntaxSelect.style.color = document.body.classList.contains('light') ? '#000' : '#fff';
   if (syntaxPreview) syntaxPreview.style.background = grad;
 }
 
@@ -973,6 +973,7 @@ settingsBtn.addEventListener('keydown', e => {
 
 themeSelect.addEventListener('change', (e) => {
   applyTheme(e.target.value);
+  updateGradient(gradientSelect.value);
   if (syntaxSelect) updateSyntaxGradient(syntaxSelect.value);
   saveState();
 });

--- a/style.css
+++ b/style.css
@@ -421,6 +421,11 @@ body.light .setting select option {
   color: #000;
 }
 
+/* Ensure selected dropdown text is black in light theme */
+body.light .setting select option:checked {
+  color: #000;
+}
+
 .gradient-select-wrapper {
   display: flex;
   align-items: center;

--- a/style.css
+++ b/style.css
@@ -360,6 +360,10 @@ body.light .window-btn:hover {
   user-select: none;
 }
 
+body.light #logo {
+  color: #000;
+}
+
 #settings {
   padding: 8px;
   height: calc(100% - 24px);
@@ -410,6 +414,13 @@ body.light #settings {
   color-scheme: var(--color-scheme);
 }
 
+body.light .setting label,
+body.light .setting select,
+body.light .setting input,
+body.light .setting select option {
+  color: #000;
+}
+
 .gradient-select-wrapper {
   display: flex;
   align-items: center;
@@ -445,6 +456,13 @@ body.light #settings {
 #gradient-select option,
 #syntax-select option {
   color: #fff;
+}
+
+body.light #gradient-select,
+body.light #syntax-select,
+body.light #gradient-select option,
+body.light #syntax-select option {
+  color: #000;
 }
 
 #angle-mode {

--- a/style.css
+++ b/style.css
@@ -417,6 +417,14 @@ body.light #settings {
   color-scheme: var(--color-scheme);
 }
 
+/* Keep settings text white in dark mode and black in light mode */
+.setting label,
+.setting select,
+.setting input,
+.setting select option {
+  color: #fff;
+}
+
 body.light .setting label,
 body.light .setting select,
 body.light .setting input,
@@ -424,7 +432,11 @@ body.light .setting select option {
   color: #000;
 }
 
-/* Ensure selected dropdown text is black in light theme */
+/* Ensure selected dropdown text matches theme */
+.setting select option:checked {
+  color: #fff;
+}
+
 body.light .setting select option:checked {
   color: #000;
 }
@@ -455,22 +467,14 @@ body.light .setting select option:checked {
 
 .setting select option {
   background: var(--settings-bg);
-  color: var(--text-color);
 }
 
-/* Ensure gradient theme dropdown text remains visible */
+/* Ensure gradient and syntax dropdown text remain legible */
 #gradient-select,
 #syntax-select,
 #gradient-select option,
 #syntax-select option {
-  color: #fff;
-}
-
-body.light #gradient-select,
-body.light #syntax-select,
-body.light #gradient-select option,
-body.light #syntax-select option {
-  color: #000;
+  color: inherit;
 }
 
 #angle-mode {

--- a/style.css
+++ b/style.css
@@ -398,7 +398,10 @@ body.light #settings {
   scrollbar-color: rgba(0,0,0,0.2) var(--settings-bg);
 }
 
-.setting label { margin-right: 4px; }
+.setting label {
+  margin-right: 4px;
+  color: #fff;
+}
 
 .setting select,
 .setting input {


### PR DESCRIPTION
## Summary
- Make top-left equals sign black in light theme
- Ensure settings labels and dropdowns use black text when light theme is active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba3249c5d8832f9b5273f07a9a224c